### PR TITLE
Fix error with database table prefix

### DIFF
--- a/Model/CustomReview.php
+++ b/Model/CustomReview.php
@@ -40,8 +40,9 @@ class CustomReview extends \Magento\Framework\Model\AbstractModel implements Cus
      */
     public function addCountRating($reviewId)
     {
-        $connection = $this->getResource()->getConnection();
-        $table = $connection->getTableName("rating_option_vote");
+        $resource = $this->getResource();
+        $connection = $resource->getConnection();
+        $table = $resource->getTableName("rating_option_vote");
         $query = 'SELECT *, SUM(rate_vote.percent) AS sum, COUNT(*) AS count, SUM(rate_vote.percent)/COUNT(*) AS average';
         $query .= ' FROM '.$table.' as rate_vote';
         $query .= ' WHERE review_id = ' . (int)$reviewId;


### PR DESCRIPTION
In a store created with a Magento database table prefix, the table prefix cannot be retrieved properly, so you'll need to use the getTableName() method of the resource object.